### PR TITLE
Fix documentation for date and datetime methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ today_bs = date.today()
 print(f"Today (BS): {today_bs}")
 
 # Convert BS to AD
-ad_date = bs_date.to_gregorian()
+ad_date = bs_date.togregorian()
 print(f"Equivalent AD Date: {ad_date}") # Output: Equivalent AD Date: 2023-09-01 (Example)
 
 # Convert AD to BS
 from datetime import date as ad_py_date
 ad_another_date = ad_py_date(2024, 1, 1)
-bs_converted_date = date.from_gregorian(ad_another_date)
+bs_converted_date = date.fromgregorian(ad_another_date)
 print(f"AD {ad_another_date} is BS {bs_converted_date}")
 
 # Formatting
@@ -140,7 +140,7 @@ now_bs_utc = now_bs_nepal.astimezone(utc_timezone)
 print(f"Now (BS, UTC): {now_bs_utc}")
 
 # Convert BS datetime to AD datetime
-ad_dt = bs_dt_aware.to_gregorian()
+ad_dt = bs_dt_aware.togregorian()
 print(f"Equivalent AD Datetime: {ad_dt}")
 
 # --- Arithmetic ---

--- a/README.md
+++ b/README.md
@@ -84,72 +84,98 @@ from bikram_sambat.timezone import nepal, utc
 # --- Bikram Sambat Dates ---
 # Create a BS date
 bs_date = date(2080, 5, 15)  # BS: 2080 Bhadra 15
-print(f"BS Date: {bs_date}")  # Output: BS Date: 2080-05-15
+print(f"BS Date: {bs_date}")
+# >> BS Date: 2080-05-15
+
 print(f"Year: {bs_date.year}, Month: {bs_date.month}, Day: {bs_date.day}")
+# >> Year: 2080, Month: 5, Day: 15
 
 # Today's BS date
 today_bs = date.today()
 print(f"Today (BS): {today_bs}")
+# >> Today (BS): 2082-04-06
 
 # Convert BS to AD
 ad_date = bs_date.togregorian()
-print(f"Equivalent AD Date: {ad_date}") # Output: Equivalent AD Date: 2023-09-01 (Example)
+print(f"Equivalent AD Date: {ad_date}")
+# >> Equivalent AD Date: 2023-09-01
 
 # Convert AD to BS
 from datetime import date as ad_py_date
 ad_another_date = ad_py_date(2024, 1, 1)
 bs_converted_date = date.fromgregorian(ad_another_date)
 print(f"AD {ad_another_date} is BS {bs_converted_date}")
+# >> AD 2024-01-01 is BS 2080-09-16
 
 # Formatting
 print(bs_date.strftime("%Y %B %d, %A (%K %N %D, %G)"))
-# Example Output: 2080 Bhadra 15, Friday (२०८० भदौ १५, शुक्रबार)
+# >> 2080 Bhadra 15, Friday (२०८० भदौ १५, शुक्रबार)
 
 # --- Bikram Sambat Times ---
 # Create a BS time (naive)
 bs_time = time(14, 30, 45)
-print(f"BS Time: {bs_time}") # Output: BS Time: 14:30:45
+print(f"BS Time: {bs_time}")
+# >> BS Time: 14:30:45
+
 
 # Create a timezone-aware BS time
-bs_time_nepal = time(10, 15, 0, tzinfo=nepal_timezone)
-print(f"BS Time (Nepal): {bs_time_nepal} {bs_time_nepal.tzname()}")
+bs_time_nepal = time(10, 15, 0, tzinfo=nepal)
+print(f"BS Time (Nepal): {bs_time_nepal} {bs_time_nepal}")
+# >> BS Time (Nepal): 10:15:00 10:15:00
+
 
 # Formatting time
 print(bs_time_nepal.strftime("%I:%M:%S %p %P [%Z]"))
-# Example Output: 10:15:00 AM पहिले [Asia/Kathmandu]
+# >> 10:15:00 AM पहिले [Asia/Kathmandu]
+
 
 # --- Bikram Sambat Datetimes ---
 # Create a naive BS datetime
 bs_dt_naive = datetime(2081, 1, 1, 10, 0, 0) # BS: 2081 Baishakh 1, 10:00 AM
 print(f"BS Datetime (naive): {bs_dt_naive}")
+# >> BS Datetime (naive): 2081-01-01T10:00:00
+
 
 # Create a timezone-aware BS datetime
-bs_dt_aware = datetime(2081, 1, 1, 10, 0, 0, tzinfo=nepal_timezone)
+bs_dt_aware = datetime(2081, 1, 1, 10, 0, 0, tzinfo=nepal)
 print(f"BS Datetime (aware): {bs_dt_aware}")
+# >> BS Datetime (aware): 2081-01-01T10:00:00+0545
+
 
 # Current BS datetime (naive)
 now_bs_naive = datetime.now()
 print(f"Now (BS, naive): {now_bs_naive}")
+# >> Now (BS, naive): 2082-04-06T03:41:28.962229
+
 
 # Current BS datetime in a specific timezone
-now_bs_nepal = datetime.now(nepal_timezone)
+now_bs_nepal = datetime.now(nepal)
 print(f"Now (BS, Nepal): {now_bs_nepal}")
+# >> Now (BS, Nepal): 2082-04-06T09:26:28.962327+0545
+
 
 # Convert to another timezone
-now_bs_utc = now_bs_nepal.astimezone(utc_timezone)
+now_bs_utc = now_bs_nepal.astimezone(utc)
 print(f"Now (BS, UTC): {now_bs_utc}")
+# >> Now (BS, UTC): 2082-04-06T03:41:28.962327+0000
+
 
 # Convert BS datetime to AD datetime
 ad_dt = bs_dt_aware.togregorian()
 print(f"Equivalent AD Datetime: {ad_dt}")
+# >> Equivalent AD Datetime: 2024-04-13 10:00:00+05:45
 
 # --- Arithmetic ---
 delta = timedelta(days=10, hours=5)
 future_dt = now_bs_nepal + delta
 print(f"10 days, 5 hours from now (BS): {future_dt}")
+# >> 10 days, 5 hours from now (BS): 2082-04-16T14:26:28.962327+0545
+
 
 diff = future_dt - now_bs_nepal
 print(f"Difference: {diff}")
+# >> Difference: 10 days, 5:00:00
+
 
 ```
 
@@ -165,7 +191,7 @@ Contributions are welcome!.
 
 Read the full documentattion here: https://bikram-sambat.readthedocs.io/en/latest/
 
-
 ## 🙌 Support
+
 If you find this project useful, consider starring ⭐ the repo or sharing it.
 For feature requests or issues, please open a ticket at the [Issue Tracker](https://github.com/ashok095/bikram-sambat/issues)

--- a/docs/api/date.rst
+++ b/docs/api/date.rst
@@ -24,10 +24,10 @@
       # Convert from Gregorian
       from datetime import date as ad_date
       ad = ad_date(2024, 4, 13)
-      bs = date.from_gregorian(ad)
+      bs = date.fromgregorian(ad)
 
       # Convert to Gregorian
-      ad_new = bs.to_gregorian()
+      ad_new = bs.togregorian()
 
       # Arithmetic
       d2 = d + timedelta(days=10)
@@ -35,5 +35,10 @@
 
       # Formatting
       print(d.strftime("%Y-%m-%d"))
+      # >> 2081-01-01
+
       print(d.strftime("%A, %B %d, %Y"))
+      # >> Saturday, Baishakh 01, 2081
+
       print(d.strftime("%G, %N %D, %K"))
+      # >> शनिबार, वैशाख ०१, २०८१

--- a/docs/api/datetime.rst
+++ b/docs/api/datetime.rst
@@ -25,10 +25,10 @@
       # Convert from Gregorian
       from datetime import datetime as ad_datetime
       ad_dt = ad_datetime(2024, 4, 13, 10, 30, 45)
-      bs_dt = datetime.from_gregorian(ad_dt)
+      bs_dt = datetime.fromgregorian(ad_dt)
 
       # Convert to Gregorian
-      ad_dt_new = bs_dt.to_gregorian()
+      ad_dt_new = bs_dt.togregorian()
 
       # Arithmetic
       dt2 = dt + timedelta(days=10, hours=5)
@@ -39,5 +39,10 @@
 
       # Formatting
       print(dt.strftime("%Y-%m-%d %H:%M:%S"))
+      # >> 2081-01-01 10:30:45
+
       print(dt_aware.strftime("%A, %B %d, %Y %I:%M:%S %p %Z"))
+      # >> Saturday, Baishakh 01, 2081 10:00:00 AM Asia/Kathmandu
+
       print(dt_aware.strftime("%G, %N %D, %K %i:%l:%s %P"))
+      # >> शनिबार, वैशाख ०१, २०८१ १०:००:०० पहिले

--- a/docs/api/time.rst
+++ b/docs/api/time.rst
@@ -23,5 +23,11 @@
 
       # Formatting
       print(t.strftime("%H:%M:%S"))
+      # >> 10:30:45
+
       print(t_aware.strftime("%I:%M:%S %p %Z"))
+      # >> 10:30:45 AM Asia/Kathmandu
+
       print(t_aware.strftime("%i:%l:%s %P"))
+      # >> १०:३०:४५ पहिले
+      

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,7 +18,7 @@ This guide provides a brief overview of the ``bikram-sambat`` library's main fea
    # >> BS Date: 2081-04-15
 
    # Convert to Gregorian
-   greg_date = bs_date.to_gregorian()
+   greg_date = bs_date.togregorian()
    print(f"Gregorian equivalent: {greg_date}")
    # >> Gregorian equivalent: 2024-07-30
 
@@ -36,7 +36,9 @@ This guide provides a brief overview of the ``bikram-sambat`` library's main fea
 
    # --- Arithmetic ---
 
-   # Perform arithmetic
-   event_date = date(2082, 1, 1)
-   days_until_event = event_date - date.today()
-   print(f"Days until new year 2082: {days_until_event.days}")
+   # Perform arithmetic between two fixed dates
+   start_date = date(2081, 12, 1) # Chaitra 1, 2081
+   end_of_year = date(2081, 12, 30) # End of Chaitra
+   days_left = end_of_year - start_date
+   print(f"Days from {start_date} to {end_of_year}: {days_left.days}")
+   # >> Days from 2081-12-01 to 2081-12-30: 29

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -17,5 +17,3 @@ This guide provides a more in-depth look at the ``bikram-sambat`` library.
    user_guide/formatting
    user_guide/conversion
 
-.. note::
-   This user guide is currently under construction. More detailed documentation will be added soon.

--- a/docs/user_guide/conversion.rst
+++ b/docs/user_guide/conversion.rst
@@ -8,7 +8,7 @@ A key feature of the ``bikram-sambat`` library is the ability to seamlessly conv
 Converting from Bikram Sambat to Gregorian
 ------------------------------------------
 
-To convert a ``date`` or ``datetime`` object from Bikram Sambat to Gregorian, use the ``to_gregorian`` method.
+To convert a ``date`` or ``datetime`` object from Bikram Sambat to Gregorian, use the ``togregorian`` method.
 
 **Date Conversion**
 
@@ -19,10 +19,12 @@ To convert a ``date`` or ``datetime`` object from Bikram Sambat to Gregorian, us
    # Create a BS date
    bs_date = date(2081, 1, 1)
    print(f"Bikram Sambat Date: {bs_date}")
+   # >> Bikram Sambat Date: 2081-01-01
 
    # Convert to Gregorian
-   ad_date = bs_date.to_gregorian()
+   ad_date = bs_date.togregorian()
    print(f"Gregorian (AD) Date: {ad_date}")
+   # >> Gregorian (AD) Date: 2024-04-13
 
 **Datetime Conversion**
 
@@ -33,15 +35,17 @@ To convert a ``date`` or ``datetime`` object from Bikram Sambat to Gregorian, us
    # Create a BS datetime in Nepal
    bs_dt = datetime(2081, 1, 1, 12, 0, 0, tzinfo=tz.nepal)
    print(f"Bikram Sambat Datetime: {bs_dt}")
+   # >> Bikram Sambat Datetime: 2081-01-01T12:00:00+0545
 
    # Convert to Gregorian
-   ad_dt = bs_dt.to_gregorian()
+   ad_dt = bs_dt.togregorian()
    print(f"Gregorian (AD) Datetime: {ad_dt}")
+   # >> Gregorian (AD) Datetime: 2024-04-13 12:00:00+05:45
 
 Converting from Gregorian to Bikram Sambat
 ------------------------------------------
 
-To convert a date or datetime from Gregorian to Bikram Sambat, use the ``from_gregorian`` class method.
+To convert a date or datetime from Gregorian to Bikram Sambat, use the ``fromgregorian`` class method.
 
 **Date Conversion**
 
@@ -53,10 +57,12 @@ To convert a date or datetime from Gregorian to Bikram Sambat, use the ``from_gr
    # Create a Gregorian date
    gregorian_date = ad_date(2024, 4, 13)
    print(f"Gregorian (AD) Date: {gregorian_date}")
+   # >> Gregorian (AD) Date: 2024-04-13
 
    # Convert to Bikram Sambat
-   bikram_sambat_date = date.from_gregorian(gregorian_date)
+   bikram_sambat_date = date.fromgregorian(gregorian_date)
    print(f"Bikram Sambat Date: {bikram_sambat_date}")
+   # >> Bikram Sambat Date: 2081-01-01
 
 **Datetime Conversion**
 
@@ -69,7 +75,9 @@ To convert a date or datetime from Gregorian to Bikram Sambat, use the ``from_gr
    # Create a Gregorian datetime
    gregorian_dt = ad_datetime(2024, 4, 13, 12, 0, 0, tzinfo=pytz.utc)
    print(f"Gregorian (AD) Datetime: {gregorian_dt}")
+   # >> Gregorian (AD) Datetime: 2024-04-13 12:00:00+00:00
 
    # Convert to Bikram Sambat
-   bikram_sambat_dt = datetime.from_gregorian(gregorian_dt)
+   bikram_sambat_dt = datetime.fromgregorian(gregorian_dt)
    print(f"Bikram Sambat Datetime: {bikram_sambat_dt}")
+   # >> Bikram Sambat Datetime: 2081-01-01T12:00:00+0000

--- a/docs/user_guide/date.rst
+++ b/docs/user_guide/date.rst
@@ -17,10 +17,12 @@ Creating a new ``date`` object is as simple as providing the year, month, and da
    # Create a specific date (New Year's Day 2081 BS)
    new_year_2081 = date(2081, 1, 1)
    print(f"New Year's Day 2081 BS: {new_year_2081}")
+   # >> New Year's Day 2081 BS: 2081-01-01
 
    # Another example (a date in the middle of the year)
    some_day = date(2080, 5, 15)
    print(f"A specific day: {some_day}")
+   # >> A specific day: 2080-05-15
 
 You can also get today's date in the Bikram Sambat calendar using the ``today()`` class method.
 
@@ -31,6 +33,7 @@ You can also get today's date in the Bikram Sambat calendar using the ``today()`
    # Get today's date
    today_bs = date.today()
    print(f"Today's date in BS is: {today_bs}")
+   # >> Today's date in BS is: 2082-04-06
 
 Accessing Date Components
 -------------------------
@@ -44,8 +47,13 @@ Once you have a ``date`` object, you can easily access its components:
    d = date(2081, 4, 15)
 
    print(f"Year: {d.year}")
+   # >> Year: 2081
+
    print(f"Month: {d.month}")
+   # >> Month: 4
+
    print(f"Day: {d.day}")
+   # >> Day: 15
 
 Comparing Dates
 ---------------
@@ -61,7 +69,9 @@ You can compare two ``date`` objects using the standard comparison operators.
    date3 = date(2081, 1, 1)
 
    print(f"{date1} < {date2}: {date1 < date2}")
+   # >> 2081-01-01 < 2081-01-02: True
    print(f"{date1} == {date3}: {date1 == date3}")
+   # >> 2081-01-01 == 2081-01-01: True
 
 Date Arithmetic
 ---------------
@@ -79,7 +89,12 @@ You can perform arithmetic on ``date`` objects using ``timedelta`` objects.
    past_date = d - delta
 
    print(f"10 days after {d} is {future_date}")
+   # >> 10 days after 2081-01-01 is 2081-01-11
+
    print(f"10 days before {d} is {past_date}")
+   # >> 10 days before 2081-01-01 is 2080-12-21
+
+
 
 You can also find the difference between two dates:
 
@@ -92,7 +107,8 @@ You can also find the difference between two dates:
 
    diff = date2 - date1
    print(f"The difference between {date1} and {date2} is {diff.days} days.")
-
+   # >> The difference between 2081-01-01 and 2081-01-11 is 10 days.
+   
 Converting to and from Gregorian Dates
 --------------------------------------
 

--- a/docs/user_guide/datetime.rst
+++ b/docs/user_guide/datetime.rst
@@ -17,6 +17,7 @@ You can create a ``datetime`` object by providing the year, month, day, hour, mi
    # Create a specific datetime
    dt = datetime(2081, 1, 1, 10, 30, 45, 123456)
    print(f"Datetime: {dt}")
+   # >> Datetime: 2081-01-01T10:30:45.123456
 
 You can also get the current datetime in the Bikram Sambat calendar using the ``now()`` class method.
 
@@ -27,11 +28,14 @@ You can also get the current datetime in the Bikram Sambat calendar using the ``
    # Get the current naive datetime
    now_naive = datetime.now()
    print(f"Current naive datetime: {now_naive}")
+   # >> Current naive datetime: 2082-04-06T01:49:00.367176
+
 
    # Get the current aware datetime in a specific timezone
    from bikram_sambat import tz
    now_aware = datetime.now(tz.nepal)
    print(f"Current aware datetime in Nepal: {now_aware}")
+   # >> Current aware datetime in Nepal: 2082-04-06T07:34:00.368572+0545
 
 Accessing Datetime Components
 -----------------------------
@@ -45,11 +49,23 @@ You can access all the components of a ``datetime`` object:
    dt = datetime(2081, 4, 15, 10, 30, 45)
 
    print(f"Year: {dt.year}")
+   # >> Year: 2081
+
    print(f"Month: {dt.month}")
+   # >> Month: 4
+
    print(f"Day: {dt.day}")
+   # >> Day: 15
+
    print(f"Hour: {dt.hour}")
+   # >> Hour: 10
+
    print(f"Minute: {dt.minute}")
+   # >> Minute: 30
+
    print(f"Second: {dt.second}")
+   # >> Second: 45
+
 
 Datetime Arithmetic
 -------------------
@@ -67,7 +83,10 @@ You can perform arithmetic on ``datetime`` objects using ``timedelta`` objects.
    past_dt = dt - delta
 
    print(f"10 days and 5 hours after {dt} is {future_dt}")
+   # >> 10 days and 5 hours after 2081-01-01T12:00:00 is 2081-01-11T17:00:00
+
    print(f"10 days and 5 hours before {dt} is {past_dt}")
+   # >> 10 days and 5 hours before 2081-01-01T12:00:00 is 2080-12-21T07:00:00
 
 You can also find the difference between two datetimes:
 
@@ -80,6 +99,9 @@ You can also find the difference between two datetimes:
 
    diff = dt2 - dt1
    print(f"The difference between {dt1} and {dt2} is {diff}")
+   # >> The difference between 2081-01-01T12:00:00 and 2081-01-11T17:00:00 is 10 days, 5:00:00
+
+
 
 Timezones
 ---------

--- a/docs/user_guide/formatting.rst
+++ b/docs/user_guide/formatting.rst
@@ -53,13 +53,44 @@ These directives allow you to format dates and times using Nepali numerals and n
 
    # Standard formatting
    print(dt.strftime("%Y-%m-%d %H:%M:%S"))
+   # >> 2081-01-01 13:30:45
+
    print(dt.strftime("%A, %B %d, %Y"))
+   # >> Saturday, Baishakh 01, 2081
+
 
    # Nepali formatting
    print(dt.strftime("%K-%N-%D %i:%l:%s %P"))
+   # >> २०८१-वैशाख-०१ ०१:३०:४५ पछिल्लो
+
    print(dt.strftime("%G, %N %D, %K"))
+   # >> शनिबार, वैशाख ०१, २०८१
 
-Parsing with ``fromstrftime`` (Not Yet Implemented)
----------------------------------------------------
 
-The ``fromstrftime`` method, which will parse a string into a ``date``, ``time``, or ``datetime`` object, is planned for a future release.
+Parsing with ``fromstrftime``
+-----------------------------
+
+The ``fromstrftime`` method, which will parse a string into a ``date``, ``time``, or ``datetime`` object, is the reverse of `strftime`.
+
+.. code-block:: python
+
+    from bikram_sambat import datetime
+
+    datetime_str = "2081-04-15 10:30:00"
+    format_str = "%Y-%m-%d %H:%M:%S"
+    dt = datetime.fromstrftime(datetime_str, format_str)
+    print(dt)
+    # >> 2081-04-15T10:30:00
+
+   date_str_nepali = "शनिबार, वैशाख ०१, २०८१"
+   format_str_date = "%G, %N %D, %K"
+   parsed_date = date.fromstrftime(date_str_nepali, format_str_date)
+   print(f"Parsed nepali date string '{date_str_nepali}': {parsed_date}")
+   # >> Parsed nepali date string 'शनिबार, वैशाख ०१, २०८१': 2081-01-01
+
+   dt_str = "2081-04-15 10:30 PM"
+   format_str_dt = "%Y-%m-%d %I:%M %p"
+   parsed_dt = datetime.fromstrftime(dt_str, format_str_dt)
+   print(f"Parsed datetime string '{dt_str}': {parsed_dt}")
+   # >> Parsed datetime string '2081-04-15 10:30 PM': 2081-04-15T22:30:00
+

--- a/docs/user_guide/time.rst
+++ b/docs/user_guide/time.rst
@@ -17,6 +17,7 @@ You can create a ``time`` object by providing the hour, minute, second, and micr
    # Create a specific time
    t = time(10, 30, 45, 123456)
    print(f"Time: {t}")
+   # >> Time: 10:30:45.123456
 
 Accessing Time Components
 -------------------------
@@ -30,9 +31,16 @@ You can access the components of a ``time`` object:
    t = time(10, 30, 45, 123456)
 
    print(f"Hour: {t.hour}")
+   # >> Hour: 10
+
    print(f"Minute: {t.minute}")
+   # >> Minute: 30
+
    print(f"Second: {t.second}")
+   # >> Second: 45
+
    print(f"Microsecond: {t.microsecond}")
+   # >> Microsecond: 123456
 
 Timezones
 ---------
@@ -46,10 +54,15 @@ You can create timezone-aware ``time`` objects by passing a ``tzinfo`` object. S
    # Create a naive time
    naive_time = time(10, 30)
    print(f"Naive time: {naive_time}")
+   # >> Naive time: 10:30:00
 
    # Create a timezone-aware time
    aware_time = time(10, 30, tzinfo=tz.nepal)
    print(f"Aware time: {aware_time}")
+   # >> Aware time: 10:30:00+05:45
+
+.. note::
+   For a `time`-only object, calculating the UTC offset for timezones with Daylight Saving Time (DST) requires a reference date. This library uses the current system date for this calculation. Therefore, the UTC offset (`%z`) for a `time` object may vary depending on the day the code is run.
 
 Formatting Times
 ----------------

--- a/docs/user_guide/timedelta.rst
+++ b/docs/user_guide/timedelta.rst
@@ -17,14 +17,17 @@ You can create a ``timedelta`` object by specifying the duration in days, second
    # A duration of 10 days
    delta1 = timedelta(days=10)
    print(f"Delta 1: {delta1}")
+   # >> Delta 1: 10 days, 0:00:00
 
    # A duration of 5 hours and 30 minutes
    delta2 = timedelta(hours=5, minutes=30)
    print(f"Delta 2: {delta2}")
+   # >> Delta 2: 5:30:00
 
    # A complex duration
    delta3 = timedelta(weeks=2, days=3, hours=4, minutes=5, seconds=6, milliseconds=7, microseconds=8)
    print(f"Delta 3: {delta3}")
+   # >> Delta 3: 17 days, 4:05:06.007008
 
 Timedelta Arithmetic
 --------------------
@@ -41,18 +44,22 @@ You can perform arithmetic with ``timedelta`` objects.
    # Add two timedeltas
    total_delta = delta1 + delta2
    print(f"{delta1} + {delta2} = {total_delta}")
+   # >> 1 day, 0:00:00 + 12:00:00 = 1 day, 12:00:00
 
    # Subtract two timedeltas
    diff_delta = delta1 - delta2
    print(f"{delta1} - {delta2} = {diff_delta}")
+   # >> 1 day, 0:00:00 - 12:00:00 = 12:00:00
 
    # Multiply a timedelta by a number
    multiplied_delta = delta1 * 2
    print(f"{delta1} * 2 = {multiplied_delta}")
+   # >> 1 day, 0:00:00 * 2.5 = 2 days, 12:00:00
 
    # Divide a timedelta by a number
    divided_delta = delta1 / 2
    print(f"{delta1} / 2 = {divided_delta}")
+   # >> 1 day, 0:00:00 / 2 = 12:00:00
 
 Using Timedeltas with Dates and Datetimes
 -----------------------------------------

--- a/docs/user_guide/timezone.rst
+++ b/docs/user_guide/timezone.rst
@@ -26,12 +26,18 @@ You can also get any timezone supported by the ``pytz`` library using the ``get_
    india_tz = tz.india
 
    print(f"Nepal Timezone: {nepal_tz}")
+   # >> Nepal Timezone: Asia/Kathmandu
+
    print(f"UTC Timezone: {utc_tz}")
+   # >> UTC Timezone: UTC
+
    print(f"India Timezone: {india_tz}")
+   # >> India Timezone: Asia/Kolkata
 
    # Get a timezone by name
    new_york_tz = tz.get_timezone('America/New_York')
    print(f"New York Timezone: {new_york_tz}")
+    # >> New York Timezone: America/New_York
 
 Creating Timezone-Aware Objects
 -------------------------------
@@ -45,10 +51,18 @@ To make a ``time`` or ``datetime`` object timezone-aware, pass a ``tzinfo`` obje
    # Create a timezone-aware datetime in Nepal
    dt_nepal = datetime(2081, 1, 1, 10, 0, 0, tzinfo=tz.nepal)
    print(f"Aware datetime in Nepal: {dt_nepal}")
+   # >> Aware datetime in Nepal: 2081-01-01T10:00:00+05:45
+
 
    # Create a timezone-aware time in New York
    t_ny = time(10, 0, 0, tzinfo=tz.get_timezone('America/New_York'))
    print(f"Aware time in New York: {t_ny}")
+   # >> Aware time in New York: 10:00:00
+
+   dt_ny = datetime(2081, 1, 1, 10, 0, 0, tzinfo=tz.get_timezone('America/New_York'))
+   print(f"Aware datetime in New York: {dt_ny}")
+   # >> Aware datetime in New York: 2081-01-01T10:00:00-05:00
+
 
 Converting Between Timezones
 ----------------------------
@@ -62,14 +76,17 @@ You can easily convert a timezone-aware ``datetime`` object to another timezone 
    # Create a datetime in Nepal time
    dt_nepal = datetime(2081, 1, 1, 10, 0, 0, tzinfo=tz.nepal)
    print(f"Datetime in Nepal: {dt_nepal}")
+   # >> Datetime in Nepal: 2081-01-01T10:00:00+05:45
 
    # Convert to UTC
    dt_utc = dt_nepal.astimezone(tz.utc)
    print(f"Datetime in UTC: {dt_utc}")
+   # >> Datetime in UTC: 2081-01-01T04:15:00+00:00
 
    # Convert to New York time
    dt_ny = dt_nepal.astimezone(tz.get_timezone('America/New_York'))
    print(f"Datetime in New York: {dt_ny}")
+   # >> Datetime in New York: 2081-01-01T00:15:00-04:00
 
 Naive vs. Aware Objects
 -----------------------
@@ -83,8 +100,10 @@ A ``datetime`` or ``time`` object is "naive" if it does not have any timezone in
    # A naive datetime
    dt_naive = datetime(2081, 1, 1, 10, 0, 0)
    print(f"Is naive? {dt_naive.tzinfo is None}")
+   # >> Is naive? True
 
    # An aware datetime
    from bikram_sambat import tz
    dt_aware = datetime(2081, 1, 1, 10, 0, 0, tzinfo=tz.nepal)
    print(f"Is aware? {dt_aware.tzinfo is not None}")
+   # >> Is aware? True


### PR DESCRIPTION
Correct method names in the documentation for date and datetime conversions and update print statements in README examples for clarity and consistency.